### PR TITLE
Use socket_read with timeout to prevent blocking

### DIFF
--- a/lib/sslshake/sslv2.rb
+++ b/lib/sslshake/sslv2.rb
@@ -53,7 +53,8 @@ module SSLShake
       end
 
       len = head & 0x7fff
-      res['raw'] = response = socket.read(len).unpack('H*')[0].upcase
+      res['raw'] = response = socket_read(socket, len, opts[:timeout], opts[:retries])
+                              .unpack('H*')[0].upcase
       raw = response.scan(/../)
 
       res['message_type'] = MESSAGE_TYPES.key(raw.shift)

--- a/lib/sslshake/tls.rb
+++ b/lib/sslshake/tls.rb
@@ -90,7 +90,8 @@ module SSLShake
       res['version'] = VERSIONS.key(raw.shift(2).join(''))
       len = raw.shift(2).join.to_i(16)
 
-      res['raw'] = response = socket.read(len).unpack('H*')[0].upcase
+      res['raw'] = response = socket_read(socket, len, opts[:timeout], opts[:retries])
+                              .unpack('H*')[0].upcase
       raw = response.scan(/../)
 
       res['handshake_type'] = HANDSHAKE_TYPES.key(raw.shift)


### PR DESCRIPTION
Some ports like (push jobs 10000, 10002) are blocking `socket.read`. This PR uses the `socket_read` to avoid this. Reported here: https://github.com/chef/inspec/issues/1091
