### PR TITLE
remove TLS_FALLBACK_SCSV

### DIFF
--- a/lib/sslshake/ciphers.rb
+++ b/lib/sslshake/ciphers.rb
@@ -354,7 +354,6 @@ module SSLShake # rubocop:disable Metrics/ModuleLength
     'FEFE' => 'SSL_RSA_FIPS_WITH_DES_CBC_SHA',
     'FEFF' => 'SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA',
     'FFE0' => 'SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA',
-    'FFE1' => 'SSL_RSA_FIPS_WITH_DES_CBC_SHA',
-    '5600' => 'TLS_FALLBACK_SCSV'
+    'FFE1' => 'SSL_RSA_FIPS_WITH_DES_CBC_SHA'
   }.invert.freeze
 end


### PR DESCRIPTION
follow-up to https://github.com/arlimus/sslshake/pull/7 , as per feedback from @adamcaudill @supergicko @atomic111 - Thank you all!!

We currently don't see a use-case where this is needed in the context of the current state of this library (see https://github.com/arlimus/sslshake/pull/7\#issuecomment-295726450 )

if google landed you here, feel free to open an issue and share your use-case.