### PR TITLE
Remove cipher suites limit for SSLv3

### DIFF
--- a/lib/sslshake/tls.rb
+++ b/lib/sslshake/tls.rb
@@ -39,7 +39,7 @@ module SSLShake
     }.freeze
 
     # https://tools.ietf.org/html/rfc6101#appendix-A.6
-    SSL3_CIPHERS = ::SSLShake::CIPHERS.select { |_, v| v < '001F' && v.length == 4 }
+    SSL3_CIPHERS = ::SSLShake::CIPHERS.select { |_, v| v.length == 4 }
     TLS_CIPHERS = ::SSLShake::CIPHERS.select { |k, _| k.start_with? 'TLS_' }
     TLS10_CIPHERS = TLS_CIPHERS.select { |_, v| v[0] == '0' && v[1] == '0' }
 


### PR DESCRIPTION
### SSLv3 cipher suites should not be limited to RFC 6101 cipher suites.

It's possible to do a SSLv3 handshake with non native SSLv3 cipher suites (described in RFC 6101).

For example all available cipher suites for SSLv3 with openssl (with a version still supporting sslv3 like OpenSSL 1.0.2-chacha (1.0.2k-dev)) can be listed with the following command: `openssl ciphers -V -ssl3 'ALL:eNULL'`.

With this fix it would possible to do:
`SSLShake.hello('www', servername:'www', port: 443, protocol: 'ssl3', ciphers: ['TLS_ECDHE_RSA_WITH_RC4_128_SHA'])`